### PR TITLE
Select templates based on template name

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Usage: zcollective [options]
         --connect-by-ip              When adding new hosts, get Zabbix to connect to those hosts by
                                      IP address instead of hostname. Useful in scenarios where you
                                      don't have control over your DNS.
+        --match-by-name              Always match templates on their 'Template Name' even if they
+                                     have a 'Visible Name'
         --lockfile=f                 Use alternative lock file
         --timeout=t                  Time out after number of seconds
 ```

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Usage: zcollective [options]
         --zabbix-pass pass           Zabbix API password
         --debug                      Enable debugging
         --noop                       Don't make changes
+        --templates-only             Only update host templates, don't create hosts
         --interface-cidr CIDR        Only consider interfaces matching the given CIDR
         --connect-by-ip              When adding new hosts, get Zabbix to connect to those hosts by
                                      IP address instead of hostname. Useful in scenarios where you
@@ -66,7 +67,7 @@ The URL, username and password options are self-explanatory.
 
 Passing ```--noop``` will report on the changes to be made, but not make any.
 
-
+Passing ```--templates-only``` will not create any hosts found in MCollective but not in Zabbix, only update the templates on existing hosts.  This is useful if you want to use some other discovery method (E.G. Zabbix discovery) but still use ZCollective to keep Template associations up to date.
 
 
 ## Example

--- a/bin/zcollective
+++ b/bin/zcollective
@@ -79,6 +79,11 @@ optparse = OptionParser.new do |opts|
         options[:connect_by_ip] = 1
     end
 
+    options[:match_by_name] = false
+    opts.on('--match-by-name','Always match templates on their \'Template Name\' even if they have a \'Visible Name\'') do
+        options[:match_by_name] = true
+    end
+
     options[:lockfile] = "/tmp/zcollective.lock"
     opts.on('--lockfile=f', 'Use alternative lock file') do |f|
         options[:lockfile] = f
@@ -164,7 +169,10 @@ zabbix_client.request( 'template.get',
     'search' => '', 
     'output' => 'extend' 
 ).each do |template|
-
+    if options[:match_by_name] and template.has_key?('host')
+        template['name'] = template['host']
+    end
+    
     log.debug( "\tName: #{template['name']} ID: #{template['templateid']}" )
     zabbix_templates[ template['name'] ] = template['templateid']
 

--- a/bin/zcollective
+++ b/bin/zcollective
@@ -68,6 +68,11 @@ optparse = OptionParser.new do |opts|
     opts.on('-n', '--noop', 'Don\'t make changes') do
         options[:noop] = true
     end
+    
+    options[:templates_only] = false
+    opts.on('-t', '--templates-only', 'Only update host templates, don\'t create hosts') do
+        options[:templates_only] = true
+    end
 
     options[:interface_cidr] = '0.0.0.0/0'
     opts.on('-c', '--interface-cidr CIDR', 'Only consider interfaces matching the given CIDR') do |c|
@@ -501,12 +506,16 @@ hosts.each do |host,data|
 
             log.info("--noop passed - not making changes")
 
+        elsif options[:templates_only]
+
+            log.info("--templates-only passed - not creating new host")
+
         else 
 
-            # If we're not in --noop mode, create the host with the
-            #  zabbix API.  Hosts need at least one interface (for now
-            #  we're just adding a Zabbix agent interface), and need
-            #  to be in a group.
+            # If we're not in --noop  or --templates-only mode, create the host
+            #   with the zabbix API.  Hosts need at least one interface (for
+            #   now we're just adding a Zabbix agent interface), and need to
+            #   be in a group.
 
             resp = zabbix_client.request( 'host.create',
                 'host'       => host,


### PR DESCRIPTION
For templates that have both a visible name and a template name, add a flag allowing the selection based on the template name field in Zabbix. This is useful for creating nice aliases for class names.
