### PR TITLE
SSL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Usage: zcollective [options]
         --template template          Add this template (only with --host)
         --ignore-classes c1,c2       Skip hosts containing given puppet classes
         --hostgroup-facts f1,f2      Create hostgroups and link hosts for given facts
+        --insecure-https             Don't validate the SSL cert
 ```
 
 The URL, username and password options are self-explanatory.

--- a/bin/zcollective
+++ b/bin/zcollective
@@ -186,11 +186,11 @@ end
 log.debug( "Connecting to Zabbix RPC service" )
 
 zabbix_client = ZCollective::ZabbixClient.new(
-    :url           => options[:zabbix_api_url],
-    :user          => options[:zabbix_user],
-    :password      => options[:zabbix_pass],
-    :debug         => options[:debug],
-    :http_timeout  => options[:http_timeout],
+    :url            => options[:zabbix_api_url],
+    :user           => options[:zabbix_user],
+    :password       => options[:zabbix_pass],
+    :debug          => options[:debug],
+    :http_timeout   => options[:http_timeout],
     :insecure_https => options[:insecure_https],
 )
 

--- a/bin/zcollective
+++ b/bin/zcollective
@@ -115,9 +115,9 @@ optparse = OptionParser.new do |opts|
         options[:hostgroup_facts] = f
     end
 
-    options[:insecurehttps] = false
+    options[:insecure_https] = false
     opts.on('--insecure-https', 'Don\'t validate the SSL cert') do
-        options[:insecurehttps] = true
+        options[:insecure_https] = true
     end
 
 end
@@ -186,12 +186,12 @@ end
 log.debug( "Connecting to Zabbix RPC service" )
 
 zabbix_client = ZCollective::ZabbixClient.new(
-    :url          => options[:zabbix_api_url],
-    :user         => options[:zabbix_user],
-    :password     => options[:zabbix_pass],
-    :debug        => options[:debug],
-    :http_timeout => options[:http_timeout],
-    :insecurehttps => options[:insecurehttps],
+    :url           => options[:zabbix_api_url],
+    :user          => options[:zabbix_user],
+    :password      => options[:zabbix_pass],
+    :debug         => options[:debug],
+    :http_timeout  => options[:http_timeout],
+    :insecure_https => options[:insecure_https],
 )
 
 log.debug( "Connected and authenticated" )

--- a/bin/zcollective
+++ b/bin/zcollective
@@ -115,6 +115,11 @@ optparse = OptionParser.new do |opts|
         options[:hostgroup_facts] = f
     end
 
+    options[:insecurehttps] = false
+    opts.on('--insecure-https', 'Don\'t validate the SSL cert') do
+        options[:insecurehttps] = true
+    end
+
 end
 
 begin
@@ -186,6 +191,7 @@ zabbix_client = ZCollective::ZabbixClient.new(
     :password     => options[:zabbix_pass],
     :debug        => options[:debug],
     :http_timeout => options[:http_timeout],
+    :insecurehttps => options[:insecurehttps],
 )
 
 log.debug( "Connected and authenticated" )

--- a/lib/zcollective/zabbixclient.rb
+++ b/lib/zcollective/zabbixclient.rb
@@ -101,7 +101,7 @@ module ZCollective
             http_timeout = @options[:http_timeout]
             http.read_timeout = http_timeout.to_i unless http_timeout.nil?
             http.use_ssl = true if uri.to_s.start_with?("https")
-            http.verify_mode = OpenSSL::SSL::VERIFY_NONE if @options[:insecurehttps]
+            http.verify_mode = OpenSSL::SSL::VERIFY_NONE if @options[:insecure_https]
 
             request = Net::HTTP::Post.new( uri.request_uri )
             request.add_field( 'Content-Type', 'application/json-rpc' )

--- a/lib/zcollective/zabbixclient.rb
+++ b/lib/zcollective/zabbixclient.rb
@@ -101,7 +101,7 @@ module ZCollective
             http_timeout = @options[:http_timeout]
             http.read_timeout = http_timeout.to_i unless http_timeout.nil?
             http.use_ssl = true if uri.to_s.start_with?("https")
-            http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+            http.verify_mode = OpenSSL::SSL::VERIFY_NONE if @options[:insecurehttps]
 
             request = Net::HTTP::Post.new( uri.request_uri )
             request.add_field( 'Content-Type', 'application/json-rpc' )

--- a/lib/zcollective/zabbixclient.rb
+++ b/lib/zcollective/zabbixclient.rb
@@ -100,6 +100,8 @@ module ZCollective
             http = Net::HTTP::Proxy(proxy.host, proxy.port).new( uri.host, uri.port )
             http_timeout = @options[:http_timeout]
             http.read_timeout = http_timeout.to_i unless http_timeout.nil?
+            http.use_ssl = true
+            http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
             request = Net::HTTP::Post.new( uri.request_uri )
             request.add_field( 'Content-Type', 'application/json-rpc' )

--- a/lib/zcollective/zabbixclient.rb
+++ b/lib/zcollective/zabbixclient.rb
@@ -100,7 +100,7 @@ module ZCollective
             http = Net::HTTP::Proxy(proxy.host, proxy.port).new( uri.host, uri.port )
             http_timeout = @options[:http_timeout]
             http.read_timeout = http_timeout.to_i unless http_timeout.nil?
-            http.use_ssl = true
+            http.use_ssl = true if uri.to_s.start_with?("https")
             http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
             request = Net::HTTP::Post.new( uri.request_uri )


### PR DESCRIPTION
The current code didn't had any ssl support, by enabling http.use_ssl. The code was SSL aware.

Becaurse http.verify_mode = OpenSSL::SSL::VERIFY_NONE is always true. The client doesn't check if the SSL cert is valid.
