### PR TITLE
Constrain netaddr gem to major version 1

### DIFF
--- a/zcollective.gemspec
+++ b/zcollective.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
         'lib/zcollective/zabbixclient.rb',
         'bin/zcollective'
     ]
-    s.add_runtime_dependency 'netaddr', '>= 1.5.0'
+    s.add_runtime_dependency 'netaddr', '~> 1.5'
     s.executables << 'zcollective'
     s.homepage    = 'http://github.com/scalefactory/zcollective'
     s.require_path = 'lib'


### PR DESCRIPTION
ZCollective uses [netaddr](https://github.com/dspinhirne/netaddr-rb) API v1. API v2 is not backwards compatible and will not work with the ZCollective code as it stands.